### PR TITLE
Added Content-Type: application/json to POST and PUT requests.

### DIFF
--- a/intercom.js
+++ b/intercom.js
@@ -71,7 +71,7 @@ exports.app = function(config) {
         var args = {
           "method": "POST",
           "url": "https://api.intercom.io/v1/users/",
-          "headers": { "Authorization": sign() },
+          "headers": { "Authorization": sign(), 'Content-Type': 'application/json' },
           "body": JSON.stringify(data)
         }
 
@@ -88,7 +88,7 @@ exports.app = function(config) {
         var args = {
           "method": "PUT",
           "url": "https://api.intercom.io/v1/users/",
-          "headers": { "Authorization": sign() },
+          "headers": { "Authorization": sign(), 'Content-Type': 'application/json' },
           "body": JSON.stringify(data)
         }
 


### PR DESCRIPTION
Without content type if one of the fields has "+" character weird things happen (e.g. custom_data starts to contain user_id etc.).
This is triggered by email addresses with plus extension (e.g. "user+ext@domain.com").
